### PR TITLE
fix default noise and add --loss_projections arg

### DIFF
--- a/loss.py
+++ b/loss.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+
 def sw_loss(true_distribution, generated_distribution, num_projections=100):
     """
     Compute the Sliced Wasserstein Distance (SWD) between two distributions.
@@ -32,3 +33,28 @@ def sw_loss(true_distribution, generated_distribution, num_projections=100):
     sliced_wasserstein_distance = torch.mean((proj_true_sorted - proj_fake_sorted) ** 2)
 
     return sliced_wasserstein_distance
+
+
+class SWDLoss(nn.Module):
+    def __init__(self, num_projections=100):
+        """
+        Initialize the Sliced Wasserstein Distance (SWD) loss.
+
+        Args:
+            num_projections (int): Number of random projection directions.
+        """
+        super(SWDLoss, self).__init__()
+        self.num_projections = num_projections
+
+    def forward(self, true_distribution, generated_distribution):
+        """
+        Compute the Sliced Wasserstein Distance (SWD) between two distributions.
+
+        Args:
+            true_distribution (Tensor): Samples from the real distribution, shape [batch_size, feature_dim].
+            generated_distribution (Tensor): Samples from the generator, shape [batch_size, feature_dim].
+
+        Returns:
+            Tensor: Sliced Wasserstein distance.
+        """
+        return sw_loss(true_distribution, generated_distribution, self.num_projections)

--- a/main.py
+++ b/main.py
@@ -4,9 +4,9 @@ import torch
 from torch.utils.data import DataLoader
 
 from datasets import PairedDataset, make_dataset
-from loss import sw_loss
+from loss import SWDLoss
 from nets import MLPRelu
-from plot import plot_model_results, plot_loss
+from plot import plot_loss, plot_model_results
 from train import train_model
 
 
@@ -56,13 +56,13 @@ def parse_args():
     parser.add_argument(
         "--source_noise",
         type=float,
-        default=0.1,
+        default=1.0,
         help="Noise level for the source dataset (if applicable).",
     )
     parser.add_argument(
         "--target_noise",
         type=float,
-        default=0.1,
+        default=1.0,
         help="Noise level for the target dataset (if applicable).",
     )
 
@@ -131,6 +131,12 @@ def parse_args():
         default=False,
         help="Plot the training and validation loss after training.",
     )
+    parser.add_argument(
+        "--loss_projections",
+        type=int,
+        default=100,
+        help="Number of random projections for the SWD loss.",
+    )
     return parser.parse_args()
 
 
@@ -191,7 +197,7 @@ def main():
         input_dim=input_dim, hidden_layers=hidden_layers, output_dim=output_dim
     ).to(device)
 
-    criterion = sw_loss
+    criterion = SWDLoss(num_projections=args.loss_projections)
 
     if args.optimizer == "sgd":
         optimizer = torch.optim.SGD(model.parameters(), lr=args.lr)
@@ -231,7 +237,11 @@ def main():
     )
 
     if args.plot_loss:
-        plot_loss(f"{args.save_dir}/training_history.json", filename=f"{args.save_dir}/loss.png")
+        plot_loss(
+            f"{args.save_dir}/training_history.json",
+            filename=f"{args.save_dir}/loss.png",
+        )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Changes
- The source and target default noise (variance) were at 0.1, better to set it to 1.
- Added a `--loss_projections` arg to control the number of random projection matrices to sample in the loss.

## Results 
Much better generation, not lying in a line anymore with 500 projections